### PR TITLE
refactor(styles): Move global CSS import to _app.tsx

### DIFF
--- a/pages/AppLayout.tsx
+++ b/pages/AppLayout.tsx
@@ -1,5 +1,4 @@
 import { Montserrat } from "next/font/google";
-import "./globals.css";
 import Navbar from "@/components/Navbar";
 import NavigationScreen from "@/components/NavigationScreen";
 import ScreenTip from "@/components/ScreenTip/ScreenTip";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,7 @@ import IntlProvider from "@/i18n/IntlProvider";
 import { usePathname } from "next/navigation";
 import { getRouteByPath } from "@/constants/routes";
 import AppLayout from "./AppLayout";
+import "./globals.css";
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const { locale } = useRouter();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,8 +9,6 @@ import { useTranslations } from "next-intl";
 import Head from "next/head";
 import React from "react";
 
-import "./globals.css";
-
 export const getStaticProps: GetStaticProps = async ({ locale, locales }) => {
 
   return {


### PR DESCRIPTION
- Remove global CSS import from AppLayout
- Add global CSS import directly in _app.tsx
- Simplify global styles management